### PR TITLE
Fix number of authors before 'et al.'

### DIFF
--- a/ThesisTemplate/bath.bst
+++ b/ThesisTemplate/bath.bst
@@ -1419,7 +1419,7 @@ FUNCTION {format.lab.names}
       nameptr #1 >
         {
           nameptr #2 =
-          numnames #3 > and
+          numnames #2 > and
             { "others" 't :=
               #1 'namesleft := }
             'skip$


### PR DESCRIPTION
# Description
This change changes the number authors to trigger 'et al.' shortening from `4 or more` to `3 or more`.

This is because [BCU academic writing guidance](https://www.bcu.ac.uk/library/services-and-support/referencing/harvard) states that [**3** or more authors must be shortened](https://bcuassets.blob.core.windows.net/docs/harvardreferencingshortguidecebe2020-132611393763341586.pdf) (See page 1, example 3); although Bath guidance is [**4** or more authors must be shortened](http://www.bath.ac.uk/library/gen/referencing/harvard-bath-print.pdf) (See section C.11) instead.

# Issue Resolved
The template was generating citations with exactly **3** authors incorrectly for BCU academic writing & style guidelines.

# Before
Generated example citation: `Pemberton, Kirkpatrick and Byers (2018)`

<img width="383" alt="Screen Shot 2022-02-12 at 10 18 12 PM" src="https://user-images.githubusercontent.com/26250962/153730285-eb017d10-bb8c-4d8b-9a77-59f8ec47c2f1.png">

# After
Generated example citation: `Pemberton et al. (2018)`

<img width="216" alt="image" src="https://user-images.githubusercontent.com/26250962/153730339-c462e9b3-79cc-4d4b-ace9-520368eb5a95.png">

All citations which do not have exactly 3 authors are _unchanged_.