### PR TITLE
 Fix date formatting to have parentheses in biblography 

### DIFF
--- a/ThesisTemplate/bath.bst
+++ b/ThesisTemplate/bath.bst
@@ -61,7 +61,7 @@ FUNCTION {output.nonnull}
   output.state mid.sentence =
     { ", " * write$ }
     { output.state after.block =
-        { add.period$ write$
+        { write$
           newline$
           "\newblock " write$
         }

--- a/ThesisTemplate/bath.bst
+++ b/ThesisTemplate/bath.bst
@@ -655,13 +655,13 @@ FUNCTION {word.in}
   " " * }
 
 FUNCTION {format.date}
-{ year "year" bibinfo.check duplicate$ empty$
-    {
-    }
-    'skip$
-  if$
-  extra.label *
+{ year empty$
+  { "" }
+  { year " (" swap$ * extra.label * ")" *}
+if$
+before.all 'output.state :=
 }
+  
 FUNCTION {format.btitle}
 { title
   duplicate$ empty$ 'skip$


### PR DESCRIPTION
# Description

Change bibliography entries to use parentheses rather than periods to meet academic style guidelines.

# Before
> Jones, J.B., 2007. Tomato plant culture. 2nd ed. CRC Press. Available from: http://doi.org/10.1201/
9781420007398.

# After
> Jones, J.B. (2007) Tomato plant culture 2nd ed. CRC Press Available from: http://doi.org/10.1201/
9781420007398.

# Before/After Images
<img width="399" alt="image" src="https://user-images.githubusercontent.com/26250962/153776368-cd71d988-5fb3-4036-a687-e8f837502b9b.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/26250962/153776323-67e5c77b-5c14-4964-b5e9-b10ec02c284e.png">

# Commit History

fb59c9a2fff79be5fcda1977ba83fc33ddba2352 - [Fix date formatting to have parentheses in biblography](https://github.com/Snuggle/bcuThesisTemplate/commit/fb59c9a2fff79be5fcda1977ba83fc33ddba2352)
32ad00a4c0f14ba952d03f53a78a90f377b01e26 - [Removed extra periods. '(Year).' to become '(Year)'](https://github.com/Snuggle/bcuThesisTemplate/commit/32ad00a4c0f14ba952d03f53a78a90f377b01e26)
